### PR TITLE
Polish addition...

### DIFF
--- a/name-languages/name-languages.json
+++ b/name-languages/name-languages.json
@@ -76,6 +76,11 @@
     "shortname": "Liberland",
     "motto": "Leven en laten leven"
   },
+  "pl": {
+    "name": "Wolna Republika Liberlandii",
+    "shortname": "Liberlandia",
+    "motto": "Żyj i pozwól żyć"
+  },
   "pt": {
     "name": "República Livre de Liberland",
     "shortname": "Liberland",


### PR DESCRIPTION
It wouldn't be Liberland but Liberlandia since it would allow you to show proper gender... and countries like Finland Ireland and Iceland are: Finlandia Irlandia and Islandia.  Also Liberlandii isn't a typo there's suppose to be two "i"s, this is from the Polish Case system...
