### PR TITLE
Official demonym plus spelling error fix

### DIFF
--- a/basic-facts/basic-facts.json
+++ b/basic-facts/basic-facts.json
@@ -31,7 +31,7 @@
   "utc_offset": "+01:00",
   "tld": [ "n/a" ],
   "calling_code": [ "n/a" ],
-  "denonym": "Liberlandian",
+  "demonym": "Librish",
   "repositories": {
     "assets": "https://github.com/liberland/assets",
     "constitution": "https://github.com/liberland/constitution",


### PR DESCRIPTION
I fixed denonym to demonym, there was a typo...

And Librish rolls off the tongue so much better than Liberlandian...

Also it makes more sense grammatically:
Poland - Polish
Finland - Finnish
Ireland - Irish
